### PR TITLE
Add responsive browser-based Tetris game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tetris</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <div class="game-container">
+        <header>
+            <h1>Tetris</h1>
+            <button id="startButton" type="button">Start Game</button>
+        </header>
+        <main>
+            <section class="board-wrapper">
+                <canvas id="board" width="300" height="600" aria-label="Tetris board" role="img"></canvas>
+                <div id="overlay" class="overlay hidden" role="status" aria-live="polite">
+                    <p id="overlayMessage"></p>
+                </div>
+            </section>
+            <aside>
+                <div class="panel">
+                    <h2>Next</h2>
+                    <canvas id="next" width="120" height="120" aria-label="Next piece" role="img"></canvas>
+                </div>
+                <div class="panel stats">
+                    <h2>Stats</h2>
+                    <div class="stat">
+                        <span>Score</span>
+                        <span id="score">0</span>
+                    </div>
+                    <div class="stat">
+                        <span>Lines</span>
+                        <span id="lines">0</span>
+                    </div>
+                    <div class="stat">
+                        <span>Level</span>
+                        <span id="level">1</span>
+                    </div>
+                </div>
+                <div class="panel controls">
+                    <h2>Controls</h2>
+                    <ul>
+                        <li><kbd>←</kbd>/<kbd>→</kbd>: Move</li>
+                        <li><kbd>↓</kbd>: Soft drop</li>
+                        <li><kbd>↑</kbd>/<kbd>X</kbd>: Rotate</li>
+                        <li><kbd>Space</kbd>: Hard drop</li>
+                        <li><kbd>P</kbd>: Pause</li>
+                    </ul>
+                </div>
+            </aside>
+        </main>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,623 @@
+const COLS = 10;
+const ROWS = 20;
+const BLOCK_SIZE = 30;
+const DROP_BASE_INTERVAL = 1000;
+
+const COLORS = {
+    I: '#38bdf8',
+    J: '#6366f1',
+    L: '#f59e0b',
+    O: '#facc15',
+    S: '#22c55e',
+    T: '#a855f7',
+    Z: '#ef4444'
+};
+
+const TETROMINOES = {
+    I: [
+        [
+            [0, 0, 0, 0],
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ],
+        [
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0],
+            [0, 0, 1, 0]
+        ],
+        [
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+            [1, 1, 1, 1],
+            [0, 0, 0, 0]
+        ],
+        [
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0],
+            [0, 1, 0, 0]
+        ]
+    ],
+    J: [
+        [
+            [1, 0, 0],
+            [1, 1, 1],
+            [0, 0, 0]
+        ],
+        [
+            [0, 1, 1],
+            [0, 1, 0],
+            [0, 1, 0]
+        ],
+        [
+            [0, 0, 0],
+            [1, 1, 1],
+            [0, 0, 1]
+        ],
+        [
+            [0, 1, 0],
+            [0, 1, 0],
+            [1, 1, 0]
+        ]
+    ],
+    L: [
+        [
+            [0, 0, 1],
+            [1, 1, 1],
+            [0, 0, 0]
+        ],
+        [
+            [0, 1, 0],
+            [0, 1, 0],
+            [0, 1, 1]
+        ],
+        [
+            [0, 0, 0],
+            [1, 1, 1],
+            [1, 0, 0]
+        ],
+        [
+            [1, 1, 0],
+            [0, 1, 0],
+            [0, 1, 0]
+        ]
+    ],
+    O: [
+        [
+            [0, 1, 1, 0],
+            [0, 1, 1, 0],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0]
+        ]
+    ],
+    S: [
+        [
+            [0, 1, 1],
+            [1, 1, 0],
+            [0, 0, 0]
+        ],
+        [
+            [0, 1, 0],
+            [0, 1, 1],
+            [0, 0, 1]
+        ],
+        [
+            [0, 0, 0],
+            [0, 1, 1],
+            [1, 1, 0]
+        ],
+        [
+            [1, 0, 0],
+            [1, 1, 0],
+            [0, 1, 0]
+        ]
+    ],
+    T: [
+        [
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 0, 0]
+        ],
+        [
+            [0, 1, 0],
+            [0, 1, 1],
+            [0, 1, 0]
+        ],
+        [
+            [0, 0, 0],
+            [1, 1, 1],
+            [0, 1, 0]
+        ],
+        [
+            [0, 1, 0],
+            [1, 1, 0],
+            [0, 1, 0]
+        ]
+    ],
+    Z: [
+        [
+            [1, 1, 0],
+            [0, 1, 1],
+            [0, 0, 0]
+        ],
+        [
+            [0, 0, 1],
+            [0, 1, 1],
+            [0, 1, 0]
+        ],
+        [
+            [0, 0, 0],
+            [1, 1, 0],
+            [0, 1, 1]
+        ],
+        [
+            [0, 1, 0],
+            [1, 1, 0],
+            [1, 0, 0]
+        ]
+    ]
+};
+
+const LINE_SCORES = [0, 100, 300, 500, 800];
+
+class Board {
+    constructor(cols, rows) {
+        this.cols = cols;
+        this.rows = rows;
+        this.grid = this.createGrid();
+    }
+
+    createGrid() {
+        return Array.from({ length: this.rows }, () => Array(this.cols).fill(null));
+    }
+
+    reset() {
+        this.grid = this.createGrid();
+    }
+
+    isInside(x, y) {
+        return x >= 0 && x < this.cols && y < this.rows;
+    }
+
+    isEmpty(x, y) {
+        if (y < 0) {
+            return true;
+        }
+        return this.grid[y][x] === null;
+    }
+
+    placePiece(piece) {
+        piece.matrix.forEach((row, y) => {
+            row.forEach((value, x) => {
+                if (value) {
+                    const boardX = piece.x + x;
+                    const boardY = piece.y + y;
+                    if (boardY >= 0) {
+                        this.grid[boardY][boardX] = piece.type;
+                    }
+                }
+            });
+        });
+    }
+
+    clearLines() {
+        let cleared = 0;
+        for (let y = this.rows - 1; y >= 0; y--) {
+            if (this.grid[y].every(cell => cell !== null)) {
+                this.grid.splice(y, 1);
+                this.grid.unshift(Array(this.cols).fill(null));
+                cleared += 1;
+                y += 1; // recheck the same row index after unshift
+            }
+        }
+        return cleared;
+    }
+}
+
+class Piece {
+    constructor(type) {
+        this.type = type;
+        this.rotationIndex = 0;
+        this.rotations = TETROMINOES[type];
+        this.matrix = this.rotations[this.rotationIndex];
+        this.x = Math.floor((COLS - this.matrix[0].length) / 2);
+        this.y = -this.getTopOffset();
+    }
+
+    rotate(direction = 1) {
+        const length = this.rotations.length;
+        this.rotationIndex = (this.rotationIndex + direction + length) % length;
+        this.matrix = this.rotations[this.rotationIndex];
+        this.y -= this.getTopOffset();
+    }
+
+    getTopOffset() {
+        const firstFilledRow = this.matrix.findIndex(row => row.some(value => value !== 0));
+        return firstFilledRow === -1 ? 0 : firstFilledRow;
+    }
+}
+
+class Game {
+    constructor() {
+        this.boardCanvas = document.getElementById('board');
+        this.boardCtx = this.boardCanvas.getContext('2d');
+        this.nextCanvas = document.getElementById('next');
+        this.nextCtx = this.nextCanvas.getContext('2d');
+        this.scoreEl = document.getElementById('score');
+        this.linesEl = document.getElementById('lines');
+        this.levelEl = document.getElementById('level');
+        this.overlay = document.getElementById('overlay');
+        this.overlayMessage = document.getElementById('overlayMessage');
+        this.startButton = document.getElementById('startButton');
+
+        this.board = new Board(COLS, ROWS);
+        this.activePiece = null;
+        this.nextPiece = this.randomPiece();
+        this.dropCounter = 0;
+        this.dropInterval = DROP_BASE_INTERVAL;
+        this.lastTime = 0;
+        this.score = 0;
+        this.lines = 0;
+        this.level = 1;
+        this.gameOver = false;
+        this.paused = false;
+        this.animationFrame = null;
+
+        this.registerEvents();
+        this.drawBoard();
+        this.drawNextPiece();
+        this.updateStats();
+        this.showOverlay('Press Start');
+    }
+
+    registerEvents() {
+        document.addEventListener('keydown', (event) => {
+            if (this.gameOver || !this.activePiece) {
+                if (event.key === ' ' && !this.gameOver) {
+                    event.preventDefault();
+                }
+                return;
+            }
+
+            switch (event.key) {
+                case 'ArrowLeft':
+                    event.preventDefault();
+                    this.movePiece(-1);
+                    break;
+                case 'ArrowRight':
+                    event.preventDefault();
+                    this.movePiece(1);
+                    break;
+                case 'ArrowDown':
+                    event.preventDefault();
+                    this.softDrop();
+                    break;
+                case 'ArrowUp':
+                case 'x':
+                case 'X':
+                    event.preventDefault();
+                    this.rotatePiece();
+                    break;
+                case ' ': // Spacebar
+                    event.preventDefault();
+                    this.hardDrop();
+                    break;
+                case 'p':
+                case 'P':
+                    event.preventDefault();
+                    this.togglePause();
+                    break;
+            }
+        });
+
+        this.startButton.addEventListener('click', () => {
+            if (this.gameOver || !this.activePiece) {
+                this.startGame();
+            } else {
+                this.resetGame();
+            }
+        });
+    }
+
+    randomPiece() {
+        const types = Object.keys(TETROMINOES);
+        const type = types[Math.floor(Math.random() * types.length)];
+        return new Piece(type);
+    }
+
+    startGame() {
+        this.resetGame();
+        this.startButton.textContent = 'Restart';
+    }
+
+    resetGame() {
+        cancelAnimationFrame(this.animationFrame);
+        this.board.reset();
+        this.score = 0;
+        this.lines = 0;
+        this.level = 1;
+        this.dropInterval = DROP_BASE_INTERVAL;
+        this.gameOver = false;
+        this.paused = false;
+        this.nextPiece = this.randomPiece();
+        this.spawnPiece();
+        this.hideOverlay();
+        this.updateStats();
+        this.lastTime = 0;
+        this.dropCounter = 0;
+        this.loop(0);
+    }
+
+    spawnPiece() {
+        this.activePiece = this.nextPiece;
+        this.activePiece.x = Math.floor((COLS - this.activePiece.matrix[0].length) / 2);
+        this.activePiece.y = -this.activePiece.getTopOffset();
+        this.nextPiece = this.randomPiece();
+        this.drawNextPiece();
+
+        if (!this.isValidPosition(this.activePiece.matrix, this.activePiece.x, this.activePiece.y)) {
+            this.endGame();
+        }
+    }
+
+    movePiece(dir) {
+        if (this.paused) return;
+        const newX = this.activePiece.x + dir;
+        if (this.isValidPosition(this.activePiece.matrix, newX, this.activePiece.y)) {
+            this.activePiece.x = newX;
+            this.draw();
+        }
+    }
+
+    softDrop() {
+        if (this.paused) return;
+        if (this.moveDown()) {
+            this.addScore(1);
+        }
+    }
+
+    hardDrop() {
+        if (this.paused) return;
+        let dropDistance = 0;
+        while (this.moveDown()) {
+            dropDistance += 1;
+        }
+        if (dropDistance > 0) {
+            this.addScore(dropDistance * 2);
+        }
+        this.lockPiece();
+    }
+
+    rotatePiece() {
+        if (this.paused) return;
+        const piece = this.activePiece;
+        const previousRotation = piece.rotationIndex;
+        const previousMatrix = piece.matrix;
+        piece.rotate(1);
+
+        const kicks = [
+            { x: 0, y: 0 },
+            { x: 1, y: 0 },
+            { x: -1, y: 0 },
+            { x: 0, y: -1 },
+            { x: 0, y: -2 },
+            { x: 2, y: 0 },
+            { x: -2, y: 0 }
+        ];
+
+        const rotatedMatrix = piece.matrix;
+        for (const offset of kicks) {
+            if (this.isValidPosition(rotatedMatrix, piece.x + offset.x, piece.y + offset.y)) {
+                piece.x += offset.x;
+                piece.y += offset.y;
+                this.draw();
+                return;
+            }
+        }
+
+        piece.rotationIndex = previousRotation;
+        piece.matrix = previousMatrix;
+    }
+
+    moveDown() {
+        const piece = this.activePiece;
+        const newY = piece.y + 1;
+        if (this.isValidPosition(piece.matrix, piece.x, newY)) {
+            piece.y = newY;
+            this.draw();
+            return true;
+        }
+        return false;
+    }
+
+    lockPiece() {
+        this.board.placePiece(this.activePiece);
+        const clearedLines = this.board.clearLines();
+        if (clearedLines > 0) {
+            this.lines += clearedLines;
+            const lineScore = LINE_SCORES[clearedLines] || 0;
+            this.addScore(lineScore * this.level);
+            this.level = Math.floor(this.lines / 10) + 1;
+            const speedMultiplier = Math.pow(0.85, this.level - 1);
+            this.dropInterval = Math.max(100, DROP_BASE_INTERVAL * speedMultiplier);
+        }
+        this.spawnPiece();
+        this.draw();
+    }
+
+    addScore(amount) {
+        this.score += amount;
+        this.updateStats();
+    }
+
+    updateStats() {
+        this.scoreEl.textContent = this.score;
+        this.linesEl.textContent = this.lines;
+        this.levelEl.textContent = this.level;
+    }
+
+    togglePause() {
+        if (this.gameOver || !this.activePiece) return;
+        this.paused = !this.paused;
+        if (this.paused) {
+            cancelAnimationFrame(this.animationFrame);
+            this.showOverlay('Paused');
+        } else {
+            this.hideOverlay();
+            this.dropCounter = 0;
+            this.lastTime = 0;
+            this.loop(0);
+        }
+    }
+
+    endGame() {
+        this.gameOver = true;
+        cancelAnimationFrame(this.animationFrame);
+        this.showOverlay('Game Over');
+    }
+
+    showOverlay(message) {
+        this.overlayMessage.textContent = message;
+        this.overlay.classList.remove('hidden');
+    }
+
+    hideOverlay() {
+        this.overlay.classList.add('hidden');
+    }
+
+    isValidPosition(matrix, offsetX, offsetY) {
+        for (let y = 0; y < matrix.length; y++) {
+            for (let x = 0; x < matrix[y].length; x++) {
+                if (matrix[y][x]) {
+                    const boardX = offsetX + x;
+                    const boardY = offsetY + y;
+                    if (!this.board.isInside(boardX, boardY) || !this.board.isEmpty(boardX, boardY)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    loop(time = 0) {
+        this.animationFrame = requestAnimationFrame((t) => this.loop(t));
+        const delta = time - this.lastTime;
+        this.lastTime = time;
+        this.dropCounter += delta;
+
+        if (this.dropCounter > this.dropInterval) {
+            if (!this.moveDown()) {
+                this.lockPiece();
+            }
+            this.dropCounter = 0;
+        }
+
+        this.draw();
+    }
+
+    draw() {
+        this.drawBoard();
+        if (this.activePiece) {
+            this.drawPiece(this.activePiece, 1);
+            this.drawGhost();
+        }
+    }
+
+    drawBoard() {
+        const ctx = this.boardCtx;
+        ctx.clearRect(0, 0, this.boardCanvas.width, this.boardCanvas.height);
+        ctx.fillStyle = '#0f172a';
+        ctx.fillRect(0, 0, this.boardCanvas.width, this.boardCanvas.height);
+
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.04)';
+        for (let x = 0; x <= COLS; x++) {
+            ctx.beginPath();
+            ctx.moveTo(x * BLOCK_SIZE, 0);
+            ctx.lineTo(x * BLOCK_SIZE, ROWS * BLOCK_SIZE);
+            ctx.stroke();
+        }
+        for (let y = 0; y <= ROWS; y++) {
+            ctx.beginPath();
+            ctx.moveTo(0, y * BLOCK_SIZE);
+            ctx.lineTo(COLS * BLOCK_SIZE, y * BLOCK_SIZE);
+            ctx.stroke();
+        }
+
+        this.board.grid.forEach((row, y) => {
+            row.forEach((cell, x) => {
+                if (cell) {
+                    this.drawBlock(x, y, COLORS[cell]);
+                }
+            });
+        });
+    }
+
+    drawPiece(piece) {
+        piece.matrix.forEach((row, y) => {
+            row.forEach((value, x) => {
+                if (value) {
+                    const drawX = piece.x + x;
+                    const drawY = piece.y + y;
+                    if (drawY >= 0) {
+                        this.drawBlock(drawX, drawY, COLORS[piece.type]);
+                    }
+                }
+            });
+        });
+    }
+
+    drawGhost() {
+        const ghost = {
+            matrix: this.activePiece.matrix,
+            x: this.activePiece.x,
+            y: this.activePiece.y
+        };
+        while (this.isValidPosition(ghost.matrix, ghost.x, ghost.y + 1)) {
+            ghost.y += 1;
+        }
+        this.boardCtx.save();
+        this.boardCtx.globalAlpha = 0.25;
+        this.drawPiece(ghost);
+        this.boardCtx.restore();
+    }
+
+    drawBlock(x, y, color) {
+        const ctx = this.boardCtx;
+        const px = x * BLOCK_SIZE;
+        const py = y * BLOCK_SIZE;
+        ctx.fillStyle = color;
+        ctx.fillRect(px + 1, py + 1, BLOCK_SIZE - 2, BLOCK_SIZE - 2);
+        ctx.strokeStyle = 'rgba(255, 255, 255, 0.1)';
+        ctx.strokeRect(px + 1, py + 1, BLOCK_SIZE - 2, BLOCK_SIZE - 2);
+    }
+
+    drawNextPiece() {
+        const ctx = this.nextCtx;
+        ctx.clearRect(0, 0, this.nextCanvas.width, this.nextCanvas.height);
+        const matrix = this.nextPiece.matrix;
+        const size = matrix.length;
+        const previewBlock = 24;
+        const offsetX = (this.nextCanvas.width - size * previewBlock) / 2;
+        const offsetY = (this.nextCanvas.height - size * previewBlock) / 2;
+
+        matrix.forEach((row, y) => {
+            row.forEach((value, x) => {
+                if (value) {
+                    ctx.fillStyle = COLORS[this.nextPiece.type];
+                    const px = offsetX + x * previewBlock;
+                    const py = offsetY + y * previewBlock;
+                    ctx.fillRect(px, py, previewBlock - 2, previewBlock - 2);
+                    ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+                    ctx.strokeRect(px, py, previewBlock - 2, previewBlock - 2);
+                }
+            });
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    new Game();
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,190 @@
+:root {
+    --bg-color: #0d0d1a;
+    --board-bg: #111827;
+    --panel-bg: rgba(17, 24, 39, 0.6);
+    --text-color: #f9fafb;
+    --accent: #38bdf8;
+    --grid-line: rgba(255, 255, 255, 0.05);
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: radial-gradient(circle at top, #1f2937, #0f172a 70%);
+    color: var(--text-color);
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 1rem;
+}
+
+.game-container {
+    width: min(100%, 960px);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+h1 {
+    margin: 0;
+    font-size: clamp(1.5rem, 4vw, 2.75rem);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+button {
+    background: var(--accent);
+    border: none;
+    color: var(--bg-color);
+    padding: 0.6rem 1.4rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:active {
+    transform: scale(0.97);
+}
+
+button:hover {
+    box-shadow: 0 10px 20px -10px rgba(56, 189, 248, 0.8);
+}
+
+main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 1.5rem;
+}
+
+.board-wrapper {
+    position: relative;
+    background: var(--board-bg);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+#board {
+    display: block;
+    width: 100%;
+    height: auto;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.95));
+    border-radius: 0.5rem;
+}
+
+.overlay {
+    position: absolute;
+    inset: 1rem;
+    display: grid;
+    place-items: center;
+    background: rgba(15, 23, 42, 0.85);
+    border-radius: 0.5rem;
+    font-size: 1.75rem;
+    text-align: center;
+    letter-spacing: 0.08em;
+}
+
+.overlay.hidden {
+    display: none;
+}
+
+aside {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.panel {
+    background: var(--panel-bg);
+    border-radius: 0.75rem;
+    padding: 1rem 1.25rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.panel h2 {
+    margin-top: 0;
+    font-size: 1.125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.stats {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.stat {
+    display: flex;
+    justify-content: space-between;
+    font-size: 1.1rem;
+}
+
+.controls ul {
+    margin: 0.5rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.95rem;
+}
+
+kbd {
+    background: rgba(148, 163, 184, 0.2);
+    padding: 0.25rem 0.45rem;
+    border-radius: 0.35rem;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 840px) {
+    main {
+        grid-template-columns: 1fr;
+    }
+
+    aside {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .panel {
+        flex: 1 1 calc(50% - 0.5rem);
+    }
+}
+
+@media (max-width: 540px) {
+    body {
+        padding: 1rem 0.5rem;
+    }
+
+    .game-container {
+        padding: 1rem;
+    }
+
+    aside {
+        flex-direction: column;
+    }
+
+    .panel {
+        flex: 1 1 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- add HTML layout with canvas-based playfield, stats panels, and controls for a Tetris game
- implement responsive styling for the game board, sidebar panels, and overlay messaging
- build JavaScript game loop covering piece spawning, rotation, line clears, scoring, levels, pause, and game over handling

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e56f6145488330a8650f77ec20d9f3